### PR TITLE
Feature Proposal: `resetHandlers` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The method `setRequestHandler` is passed a function to call when Apollo client e
 ```typescript
 const queryHandler = jest.fn().mockResolvedValue({ data: { dog: { id: 1, name: 'Rufus', breed: 'Poodle' } } });
 
-mockApolloClient.setRequestHandler(GET_DOG_QUERY, queryHandler);
+mockApolloClient.setRequestHandler(GET_DOG_QUERY, requestHandler);
 
 // ....
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The method `setRequestHandler` is passed a function to call when Apollo client e
 ```typescript
 const queryHandler = jest.fn().mockResolvedValue({ data: { dog: { id: 1, name: 'Rufus', breed: 'Poodle' } } });
 
-mockApolloClient.setRequestHandler(GET_DOG_QUERY, requestHandler);
+mockApolloClient.setRequestHandler(GET_DOG_QUERY, queryHandler);
 
 // ....
 

--- a/src/mockClient.integration.test.ts
+++ b/src/mockClient.integration.test.ts
@@ -62,10 +62,10 @@ describe('MockClient integration tests', () => {
   });
 
   describe('createMockClient configuration options', () => {
-    const requestHandlerOne = () => Promise.resolve({ data: { one: 'one' }});
-    const requestHandlerTwo = () => Promise.resolve({ data: { one: 'two' }});
+    describe('replaceHandlers', () => {
+      const requestHandlerOne = () => Promise.resolve({ data: { one: 'one' }});
+      const requestHandlerTwo = () => Promise.resolve({ data: { one: 'two' }});
 
-    describe('resetHandlers', () => {
       it('is false by default', async () => {
         mockClient = createMockClient();
 
@@ -77,7 +77,8 @@ describe('MockClient integration tests', () => {
 
         expect(actual).toEqual(expect.objectContaining({ data: { one: 'one' } }));
 
-        expect(() => mockClient.setRequestHandler(queryOne, requestHandlerTwo)).toThrow('Request handler already defined for query');
+        expect(() => mockClient.setRequestHandler(queryOne, requestHandlerTwo))
+          .toThrow('Request handler already defined for query');
       });
 
       it('allows handlers to be replaced', async () => {

--- a/src/mockClient.integration.test.ts
+++ b/src/mockClient.integration.test.ts
@@ -43,7 +43,6 @@ describe('MockClient integration tests', () => {
 
           expect(actual).toEqual(expect.objectContaining({ data: { one: 'one' } }));
         });
-
       });
 
       describe('when request handler is not defined', () => {

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -12,14 +12,10 @@ export type MockApolloClient = ApolloClient<NormalizedCacheObject> &
   { setRequestHandler: (query: DocumentNode, handler: RequestHandler) => void };
 
 export type MockClientOptions = {
-  replaceHandlers: boolean;
+  replaceHandlers?: boolean;
 };
 
-export const defaultOptions = {
-  replaceHandlers: false,
-}
-
-export const createMockClient = (options: MockClientOptions = defaultOptions): MockApolloClient => {
+export const createMockClient = (options: MockClientOptions = {}): MockApolloClient => {
   const mockLink = new MockLink(options);
 
   const client = new ApolloClient({

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -11,8 +11,16 @@ export type RequestHandlerResponse<T> = { data: T, errors?: any[] };
 export type MockApolloClient = ApolloClient<NormalizedCacheObject> &
   { setRequestHandler: (query: DocumentNode, handler: RequestHandler) => void };
 
-export const createMockClient = (): MockApolloClient => {
-  const mockLink = new MockLink();
+export type MockClientOptions = {
+  replaceHandlers: boolean;
+};
+
+export const defaultOptions = {
+  replaceHandlers: false,
+}
+
+export const createMockClient = (options: MockClientOptions = defaultOptions): MockApolloClient => {
+  const mockLink = new MockLink(options);
 
   const client = new ApolloClient({
     cache: new Cache({

--- a/src/mockLink.test.ts
+++ b/src/mockLink.test.ts
@@ -28,7 +28,7 @@ describe('class MockLink', () => {
       }).not.toThrow();
     });
 
-    it('does not throw when a handler has already been defined but override is true', () => {
+    it('does not throw when a handler has already been defined but replaceHandlers is true', () => {
       mockLink = new MockLink({ replaceHandlers: true });
       expect(() => {
         mockLink.setRequestHandler(queryOne, () => Promise.resolve({ data: {} }));

--- a/src/mockLink.test.ts
+++ b/src/mockLink.test.ts
@@ -29,9 +29,10 @@ describe('class MockLink', () => {
     });
 
     it('does not throw when a handler has already been defined but override is true', () => {
+      mockLink = new MockLink({ replaceHandlers: true });
       expect(() => {
         mockLink.setRequestHandler(queryOne, () => Promise.resolve({ data: {} }));
-        mockLink.setRequestHandler(queryOne, () => Promise.resolve({ data: {} }), {replace: true});
+        mockLink.setRequestHandler(queryOne, () => Promise.resolve({ data: {} }));
       }).not.toThrow();
     });
   });

--- a/src/mockLink.test.ts
+++ b/src/mockLink.test.ts
@@ -27,6 +27,13 @@ describe('class MockLink', () => {
         mockLink.setRequestHandler(queryTwo, () => Promise.resolve({ data: {} }));
       }).not.toThrow();
     });
+
+    it('does not throw when a handler has already been defined but override is true', () => {
+      expect(() => {
+        mockLink.setRequestHandler(queryOne, () => Promise.resolve({ data: {} }));
+        mockLink.setRequestHandler(queryOne, () => Promise.resolve({ data: {} }), {replace: true});
+      }).not.toThrow();
+    });
   });
 
   describe('method request', () => {

--- a/src/mockLink.ts
+++ b/src/mockLink.ts
@@ -1,20 +1,21 @@
 import { ApolloLink, DocumentNode, Observable, Operation, FetchResult } from 'apollo-link';
 import { removeClientSetsFromDocument } from 'apollo-utilities';
 import { print } from 'graphql/language/printer';
-import { RequestHandler, RequestHandlerResponse } from './mockClient';
+import { RequestHandler, RequestHandlerResponse, MockClientOptions, defaultOptions } from './mockClient';
 
-type RequestHandlerOptions = {
-  replace?: boolean;
-};
 
 export class MockLink extends ApolloLink {
   private requestHandlers: Record<string, RequestHandler> = {};
 
-  setRequestHandler(requestQuery: DocumentNode, handler: RequestHandler, options: RequestHandlerOptions = {}): void {
+  constructor(private options: MockClientOptions = defaultOptions) {
+    super();
+  }
+
+  setRequestHandler(requestQuery: DocumentNode, handler: RequestHandler): void {
     const key = requestToKey(requestQuery);
 
-    if (this.requestHandlers[key] && !options.replace) {
-      throw new Error(`Request handler already defined for query: ${print(requestQuery)}. You can replace this handler with the 'replace' option`);
+    if (this.requestHandlers[key] && !this.options.replaceHandlers) {
+      throw new Error(`Request handler already defined for query: ${print(requestQuery)}. Use createMockClient({ replaceHandlers: true }) to overwrite handlers.`);
     }
 
     this.requestHandlers[key] = handler;

--- a/src/mockLink.ts
+++ b/src/mockLink.ts
@@ -3,16 +3,20 @@ import { removeClientSetsFromDocument } from 'apollo-utilities';
 import { print } from 'graphql/language/printer';
 import { RequestHandler, RequestHandlerResponse } from './mockClient';
 
+type RequestHandlerOptions = {
+  replace?: boolean;
+};
+
 export class MockLink extends ApolloLink {
   private requestHandlers: Record<string, RequestHandler> = {};
 
-  setRequestHandler(requestQuery: DocumentNode, handler: RequestHandler): void {
+  setRequestHandler(requestQuery: DocumentNode, handler: RequestHandler, options: RequestHandlerOptions = {}): void {
     const key = requestToKey(requestQuery);
 
-    if (this.requestHandlers[key]) {
+    if (this.requestHandlers[key] && !options.replace) {
       throw new Error(`Request handler already defined for query: ${print(requestQuery)}`);
     }
-    
+
     this.requestHandlers[key] = handler;
   }
 

--- a/src/mockLink.ts
+++ b/src/mockLink.ts
@@ -14,7 +14,7 @@ export class MockLink extends ApolloLink {
     const key = requestToKey(requestQuery);
 
     if (this.requestHandlers[key] && !options.replace) {
-      throw new Error(`Request handler already defined for query: ${print(requestQuery)}`);
+      throw new Error(`Request handler already defined for query: ${print(requestQuery)}. You can replace this handler with the 'replace' option`);
     }
 
     this.requestHandlers[key] = handler;

--- a/src/mockLink.ts
+++ b/src/mockLink.ts
@@ -1,13 +1,12 @@
 import { ApolloLink, DocumentNode, Observable, Operation, FetchResult } from 'apollo-link';
 import { removeClientSetsFromDocument } from 'apollo-utilities';
 import { print } from 'graphql/language/printer';
-import { RequestHandler, RequestHandlerResponse, MockClientOptions, defaultOptions } from './mockClient';
-
+import { RequestHandler, RequestHandlerResponse, MockClientOptions } from './mockClient';
 
 export class MockLink extends ApolloLink {
   private requestHandlers: Record<string, RequestHandler> = {};
 
-  constructor(private options: MockClientOptions = defaultOptions) {
+  constructor(private options: MockClientOptions = {}) {
     super();
   }
 


### PR DESCRIPTION
This is a great package!

## Proposal:

I think a useful feature would be the option to overwrite handlers to make multiple requests for the same query. In particular, it would allow for a `mockClient` to be set up in a before each, and a request to be overridden in a single test for an error response (or just different data):

### Option 1: `createMockClient` takes a config object

```js
let mockClient;

const ComponentWithApollo = props => {
  return (
    <ApolloProvider client={mockClient}>
      <Component />
    </ApolloProvider>
  )
};

const successHandler = () => Promise.resolve({ data: { name: 'Rufus' }});
const errorHandler = () => Promise.reject(new Error('Oh no'));

beforeEach(() => {
  // Pass in a `replaceHandlers: true` option when creating the client
  mockClient = createMockClient({ replaceHandlers: true });
  mockClient.setRequestHandler(DOG_QUERY, successHandler);
});

// A bunch of tests using the response defined in the beforeEach:
it('shows loading screen before data returns', () => {
  const wrapper = mount(<ComponentWithApollo />);
  expect(wrapper.text()).toContain('Loading...');
  return waitForExpect(() => {
    expect(wrapper.text()).toContain('Rufus');
  });
});

...other various tests using the success handler

// override the DOG_QUERY handler for a single test
it('shows error message on error', () => {
  mockClient.setRequestHandler(DOG_QUERY, errorHandler);
  const wrapper = mount(<ComponentWithApollo />);
  return waitForExpect(() => {
    expect(wrapper.text()).toContain('Oh no');
  });
});
```

### Option 2: `client.setRequestHandler` takes a config object

A slightly simpler way to implement this (although I don't like it as much since you would have to pass the config into each individual call) would be to allow for a `replaceHandler` option on the individual `setRequestHandler` calls:

```js
beforeEach(() => {
  // create mockClient normally
  mockClient = createMockClient();
});

it('shows error message on error', () => {
  // override the DOG_QUERY handler for a single test
  mockClient.setRequestHandler(DOG_QUERY, errorHandler, { replaceHandler: true });
  const wrapper = mount(<ComponentWithApollo />);
  return waitForExpect(() => {
    expect(wrapper.text()).toContain('Oh no');
  });
});
```

If you'd like, see my first commit [537edc6](https://github.com/Mike-Gibson/mock-apollo-client/commit/537edc6941a42217546276cd44a53a76056cca5e) to see what that implementation looks like.

I'm curious to hear what you think!