### PR TITLE
Add fragment matcher mock.

### DIFF
--- a/src/mockClient.integration.test.ts
+++ b/src/mockClient.integration.test.ts
@@ -83,7 +83,9 @@ describe('MockClient integration tests', () => {
       beforeEach(() => {
         mockClient = createMockClient();
 
-        requestHandler = jest.fn().mockResolvedValue({ data: { id: 1, text: 'hello' } });
+        requestHandler = jest.fn()
+
+        requestHandler.mockResolvedValue({ data: { id: 1, text: 'hello' } });
 
         mockClient.setRequestHandler(query, requestHandler);
       });
@@ -100,7 +102,24 @@ describe('MockClient integration tests', () => {
 
           const actual = await promise;
 
+          console.log(actual)
+
           expect(actual).toEqual(expect.objectContaining({ data: { id: 1, text: 'hello' } }));
+        });
+
+        it('returns a promise which resolves to the correct value when called twice', async () => {
+          expect(promise).toBeInstanceOf(Promise);
+
+          const actual = await promise;
+
+          expect(actual).toEqual(expect.objectContaining({ data: { id: 1, text: 'hello' } }));
+
+          requestHandler.mockResolvedValue({ data: { id: 2, text: 'world' } });
+          promise = mockClient.query({ query });
+
+          const actualSecondCall = await promise;
+
+          expect(actualSecondCall).toEqual(expect.objectContaining({ data: { id: 2, text: 'world' } }));
         });
       });
     });

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -11,12 +11,16 @@ export type RequestHandlerResponse<T> = { data: T, errors?: any[] };
 export type MockApolloClient = ApolloClient<NormalizedCacheObject> &
   { setRequestHandler: (query: DocumentNode, handler: RequestHandler) => void };
 
+// Taken from the suggestion here: https://github.com/apollographql/react-apollo/issues/1747#issuecomment-562658518
+const fragmentMatcher = { match: () => true }
+
 export const createMockClient = (): MockApolloClient => {
   const mockLink = new MockLink();
 
   const client = new ApolloClient({
     cache: new Cache({
       addTypename: false, // TODO: Handle addTypename?
+      fragmentMatcher,
     }),
     link: mockLink,
   });


### PR DESCRIPTION
Hi,

Thanks for writing a useful library! 

My GraphQL code uses fragments.  When I run the tests using the library, I get the following problem: 

```
  console.warn node_modules/ts-invariant/lib/invariant.js:33
    You're using fragments in your queries, but either don't have the addTypename:
      true option set in Apollo Client, or you are trying to write a fragment to the store without the __typename.
       Please turn on the addTypename option and include __typename when writing fragments so that Apollo Client
       can accurately match fragments.

  console.warn node_modules/ts-invariant/lib/invariant.js:33
    DEPRECATION WARNING: using fragments without __typename is unsupported behavior and will be removed in future versions of Apollo client. You should fix this and set addTypename to true now.
```

There are a few people experiencing this problem, as you can see here: https://github.com/apollographql/react-apollo/issues/1747

One way around this problem is to write a custom fragment matcher that always returns true.  After I applied this change locally, I stopped seeing the warning.  

I wasn't sure what tests to write.  To me, it seemed that existing tests should continue passing, because the problem being fixed is a warning in the console.  Therefore, it has nothing to assert against.  If you have any suggestions, let me know.  