### PR TITLE
Adds client constructor options

### DIFF
--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -11,7 +11,9 @@ export type RequestHandlerResponse<T> = { data: T, errors?: any[] };
 export type MockApolloClient = ApolloClient<NormalizedCacheObject> &
   { setRequestHandler: (query: DocumentNode, handler: RequestHandler) => void };
 
-export const createMockClient = (options?: Partial<ApolloClientOptions<NormalizedCacheObject>>): MockApolloClient => {
+export type MockApolloClientOptions = Partial<Omit<ApolloClientOptions<NormalizedCacheObject>, 'link'>>;
+
+export const createMockClient = (options?: MockApolloClientOptions): MockApolloClient => {
   const mockLink = new MockLink();
 
   const client = new ApolloClient({

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -20,8 +20,8 @@ export const createMockClient = (options?: MockApolloClientOptions): MockApolloC
     cache: new Cache({
       addTypename: false, // TODO: Handle addTypename?
     }),
-    link: mockLink,
-    ...options
+    ...options,
+    link: mockLink
   });
 
   const mockMethods = {

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -1,4 +1,4 @@
-import ApolloClient from 'apollo-client';
+import ApolloClient, { ApolloClientOptions } from 'apollo-client';
 import { InMemoryCache as Cache, NormalizedCacheObject } from 'apollo-cache-inmemory';
 import { DocumentNode } from 'apollo-link';
 import { MockLink } from './mockLink';
@@ -11,7 +11,7 @@ export type RequestHandlerResponse<T> = { data: T, errors?: any[] };
 export type MockApolloClient = ApolloClient<NormalizedCacheObject> &
   { setRequestHandler: (query: DocumentNode, handler: RequestHandler) => void };
 
-export const createMockClient = (): MockApolloClient => {
+export const createMockClient = (options?: Partial<ApolloClientOptions<NormalizedCacheObject>>): MockApolloClient => {
   const mockLink = new MockLink();
 
   const client = new ApolloClient({
@@ -19,6 +19,7 @@ export const createMockClient = (): MockApolloClient => {
       addTypename: false, // TODO: Handle addTypename?
     }),
     link: mockLink,
+    ...options
   });
 
   const mockMethods = {


### PR DESCRIPTION
Includes the options object to the constructor, that passes the options to the apollo-client constructor.
This allows to use things like typeDefs and resolvers that we can have on other clients, to the mocked client.