### PR TITLE
Improve handling when queries contain @client directives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The examples have been adapted from the official `react-apollo` testing docs and
 
 Consider the file below, which contains a single GraphQL query and a component which is responsible for rendering the result of the query:
 
-```typescript
+```tsx
 // dog.ts
 
 import * as React from 'react';
@@ -72,7 +72,7 @@ export const Dog = ({ name }) => (
 
 To unit test this component using `mock-apollo-client`, the test file could look like the following:
 
-```typescript
+```tsx
 // dog.test.ts
 
 import { mount, ReactWrapper } from 'enzyme';

--- a/src/mockClient.integration.test.ts
+++ b/src/mockClient.integration.test.ts
@@ -1,18 +1,23 @@
+import { ApolloQueryResult } from 'apollo-client';
 import gql from 'graphql-tag';
 
 // Currently do not test against all valid peer dependency versions of apollo
 // Would be nice to have, but can't find an elegant way of doing it.
 
 import { createMockClient, MockApolloClient } from './mockClient';
-import { ApolloQueryResult } from 'apollo-client';
 
 describe('MockClient integration tests', () => {
   let mockClient: MockApolloClient;
 
+  beforeEach(() => {
+    jest.spyOn(console, 'warn')
+      .mockReset();
+  });
+
   describe('Simple queries', () => {
     const queryOne = gql`query One {one}`;
     const queryTwo = gql`query Two {two}`;
-    
+
     let requestHandlerOne: jest.Mock;
     let resolveRequestOne: Function;
 
@@ -40,6 +45,10 @@ describe('MockClient integration tests', () => {
 
         expect(actual).toEqual(expect.objectContaining({ data: { one: 'one' } }));
       });
+
+      it('throws when a handler is added for the same query', () => {
+        expect(() => mockClient.setRequestHandler(queryOne, jest.fn())).toThrowError('Request handler already defined ');
+      });
     });
 
     describe('Given request handler is not defined', () => {
@@ -58,31 +67,66 @@ describe('MockClient integration tests', () => {
   });
 
   describe('Client directives', () => {
-    describe('Given query which entirely uses cache', () => {
-      const clientDirectiveQuery = gql` { visibilityFilter @client }`;
+    describe('Given entire query is client-side and client side resolvers exist', () => {
+      const query = gql` { visibilityFilter @client }`;
 
       let requestHandler: jest.Mock;
 
       beforeEach(() => {
-        // Empty resolvers required when only using client cache
-        // https://www.apollographql.com/docs/react/data/local-state/#handling-client-fields-with-the-cache
-        mockClient = createMockClient({ resolvers: {} });
+        mockClient = createMockClient({
+          resolvers: {
+            Query: {
+              visibilityFilter: () => 'client resolver data',
+            },
+          },
+        });
 
-        requestHandler = jest.fn().mockResolvedValue({ data: { visibilityFilter: 'mock handler data' } });
-        mockClient.writeData({ data: { visibilityFilter: 'mock cache data' } });
-
-        mockClient.setRequestHandler(clientDirectiveQuery, requestHandler);
+        requestHandler = jest.fn().mockResolvedValue({
+          data: {
+            visibilityFilter: 'handler data',
+          },
+        });
       });
 
-      it('uses local state and does not call request handler', async () => {
-        const result = await mockClient.query({ query: clientDirectiveQuery });
+      it('warns when request handler is added', () => {
+        mockClient.setRequestHandler(query, requestHandler);
 
-        expect(result.data).toEqual({ visibilityFilter: 'mock cache data' });
-        expect(requestHandler).not.toBeCalled();
+        expect(console.warn).toBeCalledTimes(1);
+        expect(console.warn).toBeCalledWith('Warning: mock-apollo-client - The query is entirely client side (using @client directives) and resolvers have been configured. ' +
+          'The request handler will not be called.');
       });
     });
 
-    describe('Given query which partially uses cache', () => {
+    describe('Given entire query is client-side and client side resolvers do not exist', () => {
+      const query = gql` { visibilityFilter @client }`;
+
+      let requestHandler: jest.Mock;
+
+      beforeEach(() => {
+        mockClient = createMockClient({
+          resolvers: undefined,
+        });
+
+        requestHandler = jest.fn().mockResolvedValue({
+          data: {
+            visibilityFilter: 'handler data',
+          },
+        });
+      });
+
+      it('does not warn when request handler is added and handles request', async () => {
+        mockClient.setRequestHandler(query, requestHandler);
+
+        expect(console.warn).not.toBeCalled();
+
+        const result = await mockClient.query({ query });
+
+        expect(result.data).toEqual({ visibilityFilter: 'handler data' });
+        expect(requestHandler).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('Given part of the query is client-side and client side resolvers exist', () => {
       const query = gql`
         query User {
           user {
@@ -96,20 +140,59 @@ describe('MockClient integration tests', () => {
       let requestHandler: jest.Mock;
 
       beforeEach(() => {
-        // Empty resolvers required when only using client cache
-        // https://www.apollographql.com/docs/react/data/local-state/#handling-client-fields-with-the-cache
-        mockClient = createMockClient({ resolvers: {} });
+        mockClient = createMockClient({
+          resolvers: {
+            Query: {
+              user: () => ({ isLoggedIn: true }),
+            },
+          },
+        });
 
-        requestHandler = jest.fn().mockResolvedValue({ data: { user: { id: 1, name: 'bob' } } });
-        mockClient.writeData({ data: { user: { isLoggedIn: true } } });
-
-        mockClient.setRequestHandler(query, requestHandler);
+        requestHandler = jest.fn().mockResolvedValue({ data: { user: { id: 1, name: 'bob', isLoggedIn: false } } });
       });
 
-      it('combines local state and request handler result', async () => {
+      it('does not warn when request handler is added and handles request with merging', async () => {
+        mockClient.setRequestHandler(query, requestHandler);
+
+        expect(console.warn).not.toBeCalled();
+
         const result = await mockClient.query({ query });
 
         expect(result.data).toEqual({ user: { id: 1, name: 'bob', isLoggedIn: true } });
+        expect(requestHandler).toBeCalledTimes(1);
+        expect(console.warn).not.toBeCalled();
+      });
+    });
+
+    describe('Given part of the query is client-side and client side resolvers do not exist', () => {
+      const query = gql`
+        query User {
+          user {
+            id
+            name
+            isLoggedIn @client
+          }
+        }
+      `;
+
+      let requestHandler: jest.Mock;
+
+      beforeEach(() => {
+        mockClient = createMockClient({
+          resolvers: undefined,
+        });
+
+        requestHandler = jest.fn().mockResolvedValue({ data: { user: { id: 1, name: 'bob', isLoggedIn: false } } });
+      });
+
+      it('does not warn when request handler is added and handles request', async () => {
+        mockClient.setRequestHandler(query, requestHandler);
+
+        expect(console.warn).not.toBeCalled();
+
+        const result = await mockClient.query({ query });
+
+        expect(result.data).toEqual({ user: { id: 1, name: 'bob', isLoggedIn: false } });
         expect(requestHandler).toBeCalledTimes(1);
       });
     });


### PR DESCRIPTION
Initially raised in #12

Currently, mock-apollo-client generates the key for a request by removing `@client`. directives. This assumes that fields with the `@client` directive are removed by Apollo client before being passed to the link. This is not always correct - if local resolvers are not configured then fields with `@client` directives are passed down to the link. This meant that handlers would not be found, and additionally meant that registering two queries which were entirely client-side threw an error, as the key would end up as null.

This PR changes it to support when queries are passed down which still include `@client directives`. It does this by generating up to 2 keys for each handler - one with and one without `@client` directives.

Only issue would be if trying to register two different handlers for two queries that differ only by `@client` directives, but I'd expect this to be rare.