### PR TITLE
Support Apollo Client v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -665,6 +665,12 @@
         "pretty-format": "^25.1.0"
       }
     },
+    "@types/node": {
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,61 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apollo/client": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.1.3.tgz",
+      "integrity": "sha512-zXMiaj+dX0sgXIwEV5d/PI6B8SZT2bqlKNjZWcEXRY7NjESF5J3nd4v8KOsrhHe+A3YhNv63tIl35Sq7uf41Pg==",
+      "dev": true,
+      "requires": {
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.5.2",
+        "@wry/equality": "^0.2.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.11.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.12.1",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^1.2.0",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      },
+      "dependencies": {
+        "@wry/context": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
+          "integrity": "sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@wry/equality": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
+          "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "graphql-tag": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
+          "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==",
+          "dev": true
+        },
+        "optimism": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.1.tgz",
+          "integrity": "sha512-t8I7HM1dw0SECitBYAqFOVHoBAHEQBTeKjIL9y9ImHzAVkdyPK4ifTgM4VJRDtTUY4r/u5Eqxs4XcGPHaoPkeQ==",
+          "dev": true,
+          "requires": {
+            "@wry/context": "^0.5.2"
+          }
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -575,12 +630,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/graphql": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.3.tgz",
-      "integrity": "sha512-UoCovaxbJIxagCvVfalfK7YaNhmxj3BQFRQ2RHQKLiu+9wNXhJnlbspsLHt/YQM99IaLUUFJNzCwzc6W0ypMeQ==",
-      "dev": true
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -616,12 +665,6 @@
         "pretty-format": "^25.1.0"
       }
     },
-    "@types/node": {
-      "version": "12.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
-      "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
-      "dev": true
-    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -648,25 +691,6 @@
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==",
       "dev": true
-    },
-    "@wry/context": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
-      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
-      "dev": true,
-      "requires": {
-        "@types/node": ">=6",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@wry/equality": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
-      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.3"
-      }
     },
     "abab": {
       "version": "2.0.3",
@@ -749,69 +773,6 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
-      }
-    },
-    "apollo-cache": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.2.tgz",
-      "integrity": "sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==",
-      "dev": true,
-      "requires": {
-        "apollo-utilities": "^1.3.2",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-cache-inmemory": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.2.tgz",
-      "integrity": "sha512-AyCl3PGFv5Qv1w4N9vlg63GBPHXgMCekZy5mhlS042ji0GW84uTySX+r3F61ZX3+KM1vA4m9hQyctrEGiv5XjQ==",
-      "dev": true,
-      "requires": {
-        "apollo-cache": "^1.3.2",
-        "apollo-utilities": "^1.3.2",
-        "optimism": "^0.9.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
-      }
-    },
-    "apollo-client": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.3.tgz",
-      "integrity": "sha512-DS8pmF5CGiiJ658dG+mDn8pmCMMQIljKJSTeMNHnFuDLV0uAPZoeaAwVFiAmB408Ujqt92oIZ/8yJJAwSIhd4A==",
-      "dev": true,
-      "requires": {
-        "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.3.2",
-        "apollo-link": "^1.0.0",
-        "apollo-utilities": "1.3.2",
-        "symbol-observable": "^1.0.2",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
-    },
-    "apollo-link": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.12.tgz",
-      "integrity": "sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==",
-      "dev": true,
-      "requires": {
-        "apollo-utilities": "^1.3.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.19"
-      }
-    },
-    "apollo-utilities": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
-      "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
-      "dev": true,
-      "requires": {
-        "@wry/equality": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.4.0",
-        "tslib": "^1.9.3"
       }
     },
     "argparse": {
@@ -1862,18 +1823,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.4.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz",
-      "integrity": "sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==",
-      "dev": true,
-      "requires": {
-        "iterall": "^1.2.2"
-      }
-    },
-    "graphql-tag": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
-      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+      "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==",
       "dev": true
     },
     "growly": {
@@ -1970,6 +1922,15 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "html-encoding-sniffer": {
@@ -2297,12 +2258,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "iterall": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
-      "dev": true
     },
     "jest": {
       "version": "25.1.0",
@@ -2969,6 +2924,15 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
@@ -3197,6 +3161,12 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -3296,15 +3266,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "optimism": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.9.6.tgz",
-      "integrity": "sha512-bWr/ZP32UgFCQAoSkz33XctHwpq2via2sBvGvO5JIlrU8gaiM0LvoKj3QMle9LWdSKlzKik8XGSerzsdfYLNxA==",
-      "dev": true,
-      "requires": {
-        "@wry/context": "^0.4.0"
       }
     },
     "optionator": {
@@ -3461,6 +3422,17 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
+      }
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "psl": {
@@ -4745,16 +4717,6 @@
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
       "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==",
       "dev": true
-    },
-    "zen-observable-ts": {
-      "version": "0.8.19",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
-      "integrity": "sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,18 +29,15 @@
   "homepage": "https://github.com/mike-gibson/mock-apollo-client#readme",
   "dependencies": {},
   "devDependencies": {
-    "@types/graphql": "^14.2.3",
+    "@apollo/client": "^3.1.3",
     "@types/jest": "^25.1.4",
-    "apollo-cache-inmemory": "^1.6.2",
-    "apollo-client": "^2.6.3",
-    "graphql": "^14.4.2",
-    "graphql-tag": "^2.10.1",
+    "graphql": "^15.3.0",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "apollo-client": "~2.5.0 || ~2.6.0"
+    "@apollo/client": "^3.0.0"
   },
   "files": [
     "dist/**/*"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@apollo/client": "^3.1.3",
     "@types/jest": "^25.1.4",
+    "@types/node": "^14.6.0",
     "graphql": "^15.3.0",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",

--- a/src/mockClient.integration.test.ts
+++ b/src/mockClient.integration.test.ts
@@ -66,6 +66,10 @@ describe('MockClient integration tests', () => {
   });
 
   describe('Client directives', () => {
+    // Note: React apollo 3 no longer passes @client directives down to the link (regardless of whether
+    // client-side resolvers have been configured).
+    // See https://github.com/apollographql/apollo-client/blob/master/CHANGELOG.md#apollo-client-300
+
     describe('Given entire query is client-side and client side resolvers exist', () => {
       const query = gql` { visibilityFilter @client }`;
 
@@ -87,12 +91,16 @@ describe('MockClient integration tests', () => {
         });
       });
 
-      it('warns when request handler is added', () => {
+      it('warns when request handler is added and does not handle request', async () => {
         mockClient.setRequestHandler(query, requestHandler);
 
         expect(console.warn).toBeCalledTimes(1);
-        expect(console.warn).toBeCalledWith('Warning: mock-apollo-client - The query is entirely client side (using @client directives) and resolvers have been configured. ' +
-          'The request handler will not be called.');
+        expect(console.warn).toBeCalledWith('Warning: mock-apollo-client - The query is entirely client side (using @client directives) so the request handler will not be registered.');
+
+        const result = await mockClient.query({ query });
+
+        expect(result.data).toEqual({ visibilityFilter: 'client resolver data' });
+        expect(requestHandler).not.toHaveBeenCalled();
       });
     });
 
@@ -113,15 +121,16 @@ describe('MockClient integration tests', () => {
         });
       });
 
-      it('does not warn when request handler is added and handles request', async () => {
+      it('warns when request handler is added and does not handle request', async () => {
         mockClient.setRequestHandler(query, requestHandler);
 
-        expect(console.warn).not.toBeCalled();
+        expect(console.warn).toBeCalledTimes(1);
+        expect(console.warn).toBeCalledWith('Warning: mock-apollo-client - The query is entirely client side (using @client directives) so the request handler will not be registered.');
 
         const result = await mockClient.query({ query });
 
-        expect(result.data).toEqual({ visibilityFilter: 'handler data' });
-        expect(requestHandler).toHaveBeenCalledTimes(1);
+        expect(result.data).toEqual({});
+        expect(requestHandler).not.toHaveBeenCalled();
       });
     });
 

--- a/src/mockClient.integration.test.ts
+++ b/src/mockClient.integration.test.ts
@@ -1,5 +1,4 @@
-import { ApolloQueryResult } from 'apollo-client';
-import gql from 'graphql-tag';
+import { ApolloQueryResult, gql } from '@apollo/client/core';
 
 // Currently do not test against all valid peer dependency versions of apollo
 // Would be nice to have, but can't find an elegant way of doing it.

--- a/src/mockClient.test.ts
+++ b/src/mockClient.test.ts
@@ -1,5 +1,5 @@
-import ApolloClient from 'apollo-client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import { ApolloClient } from '@apollo/client/core';
+import { InMemoryCache } from '@apollo/client/cache';
 import { MockLink } from './mockLink';
 
 import { createMockClient } from './mockClient';

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -1,7 +1,6 @@
-import ApolloClient, { ApolloClientOptions } from 'apollo-client';
-import { InMemoryCache as Cache, NormalizedCacheObject } from 'apollo-cache-inmemory';
-import { DocumentNode } from 'apollo-link';
-import { removeClientSetsFromDocument } from 'apollo-utilities';
+import { ApolloClientOptions, ApolloClient, DocumentNode } from '@apollo/client/core';
+import { InMemoryCache as Cache, NormalizedCacheObject } from '@apollo/client/cache';
+import { removeClientSetsFromDocument } from '@apollo/client/utilities';
 import { MockLink } from './mockLink';
 
 export type RequestHandler<TData = any, TVariables = any> =

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -1,6 +1,5 @@
 import { ApolloClientOptions, ApolloClient, DocumentNode } from '@apollo/client/core';
 import { InMemoryCache as Cache, NormalizedCacheObject } from '@apollo/client/cache';
-import { removeClientSetsFromDocument } from '@apollo/client/utilities';
 import { MockLink } from './mockLink';
 
 export type RequestHandler<TData = any, TVariables = any> =
@@ -29,19 +28,8 @@ export const createMockClient = (options?: MockApolloClientOptions): MockApolloC
   });
 
   const mockMethods = {
-    setRequestHandler: (query: DocumentNode, handler: RequestHandler) => {
-      if (removeClientSetsFromDocument(query) === null && areResolversDefined(client)) {
-        console.warn('Warning: mock-apollo-client - The query is entirely client side (using @client directives) and resolvers have been configured. ' +
-          'The request handler will not be called.');
-      }
-
-      mockLink.setRequestHandler(query, handler);
-    },
+    setRequestHandler: mockLink.setRequestHandler.bind(mockLink),
   };
 
   return Object.assign(client, mockMethods);
 }
-
-const areResolversDefined = (client: ApolloClient<any>) =>
-  // getResolvers returns empty object if not defined, so cannot check for truthy value
-  client.getResolvers() === client.getResolvers();

--- a/src/mockLink.test.ts
+++ b/src/mockLink.test.ts
@@ -1,5 +1,4 @@
-import { Operation } from 'apollo-link';
-import gql from 'graphql-tag';
+import { gql, Operation } from '@apollo/client/core';
 
 import { MockLink } from './mockLink';
 

--- a/src/mockLink.test.ts
+++ b/src/mockLink.test.ts
@@ -1,4 +1,5 @@
-import { gql, Operation } from '@apollo/client/core';
+import { gql, Operation, Observer } from '@apollo/client/core';
+import { print } from 'graphql';
 
 import { MockLink } from './mockLink';
 
@@ -9,6 +10,9 @@ describe('class MockLink', () => {
   const queryTwo = gql`query Two {two}`;
 
   beforeEach(() => {
+    jest.spyOn(console, 'warn')
+      .mockReset();
+
     mockLink = new MockLink();
   });
 
@@ -18,6 +22,8 @@ describe('class MockLink', () => {
 
       expect(() => mockLink.setRequestHandler(queryOne, () => <any>{}))
         .toThrow('Request handler already defined for query');
+
+      expect(console.warn).not.toBeCalled();
     });
 
     it('does not throw when two handlers are added for two different queries', () => {
@@ -28,31 +34,17 @@ describe('class MockLink', () => {
     });
 
     describe('when queries contain @client directives', () => {
-      const clientSideQueryOne = gql`query One {one @client}`;
-      const clientSideQueryTwo = gql`query Two {two @client}`;
+      const clientSideQuery = gql`query One {one @client}`;
       const mixedQueryOne = gql`query Three {a @client b}`;
       const mixedQueryTwo = gql`query Four {c @client d}`;
 
-      it('does not throw when adding client-side query', () => {
+      it('does not throw, but warns, when adding client-side query', () => {
         expect(() => {
-          mockLink.setRequestHandler(clientSideQueryOne, jest.fn());
+          mockLink.setRequestHandler(clientSideQuery, jest.fn());
         }).not.toThrow();
-      });
 
-      it('throws when the same client-side only query is added twice', () => {
-        mockLink.setRequestHandler(clientSideQueryOne, jest.fn());
-
-        expect(() => {
-          mockLink.setRequestHandler(clientSideQueryOne, jest.fn());
-        }).toThrowError('Request handler already defined for query');
-      });
-
-      it('does not throw when two different client-side only queries are added', () => {
-        mockLink.setRequestHandler(clientSideQueryOne, jest.fn());
-
-        expect(() => {
-          mockLink.setRequestHandler(clientSideQueryTwo, jest.fn());
-        }).not.toThrow();
+        expect(console.warn).toBeCalledTimes(1);
+        expect(console.warn).toBeCalledWith('Warning: mock-apollo-client - The query is entirely client side (using @client directives) so the request handler will not be registered.');
       });
 
       it('throws when the same mixed query is added twice', () => {
@@ -61,6 +53,8 @@ describe('class MockLink', () => {
         expect(() => {
           mockLink.setRequestHandler(mixedQueryOne, jest.fn());
         }).toThrowError('Request handler already defined for query');
+
+        expect(console.warn).not.toBeCalled();
       });
 
       it('does not throw when two different mixed queries are added', () => {
@@ -69,6 +63,8 @@ describe('class MockLink', () => {
         expect(() => {
           mockLink.setRequestHandler(mixedQueryTwo, jest.fn());
         }).not.toThrow();
+
+        expect(console.warn).not.toBeCalled();
       });
     });
   });
@@ -76,164 +72,99 @@ describe('class MockLink', () => {
   describe('method request', () => {
     const queryOneOperation = { query: queryOne, variables: { a: 'one'} } as Partial<Operation> as Operation;
 
-    it('throws when a handler is not defined for the query', () => {
-      expect(() => mockLink.request(queryOneOperation))
-        .toThrow('Request handler not defined for query');
+    const createMockObserver = (): jest.Mocked<Observer<any>> => ({
+      next: jest.fn(),
+      error: jest.fn(),
+      complete: jest.fn(),
     });
 
-    it('does not throw when a handler is defined for the query', () => {
-      mockLink.setRequestHandler(queryOne, () => Promise.resolve({ data: {} }));
+    it('returns an error when a handler is not defined for the query', async () => {
+      const observable = mockLink.request(queryOneOperation);
 
-      expect(() => mockLink.request(queryOneOperation))
-        .not.toThrow();
+      const observer = createMockObserver();
+
+      observable.subscribe(observer);
+
+      await new Promise(r => setTimeout(r, 0));
+
+      expect(observer.next).not.toBeCalled();
+      expect(observer.error).toBeCalledTimes(1);
+      expect(observer.error).toBeCalledWith(new Error(`Request handler not defined for query: ${print(queryOne)}`));
+      expect(observer.complete).not.toBeCalled();
     });
 
     it('correctly executes the handler when the handler successfully resolves', async () => {
       const handler = jest.fn().mockResolvedValue({ data: 'Query one result' });
       mockLink.setRequestHandler(queryOne, handler);
+      const observer = createMockObserver();
 
-      const observer = mockLink.request(queryOneOperation);
+      const observerable = mockLink.request(queryOneOperation);
 
-      const next = jest.fn();
-      const error = jest.fn();
-      const complete = jest.fn();
-
-      observer.subscribe(next, error, complete);
+      observerable.subscribe(observer);
 
       await new Promise(r => setTimeout(r, 0));
 
       expect(handler).toBeCalledTimes(1);
       expect(handler).toBeCalledWith({ a: 'one' });
 
-      expect(next).toBeCalledTimes(1);
-      expect(next).toBeCalledWith({ data: 'Query one result' });
-      expect(error).not.toBeCalled();
-      expect(complete).toBeCalledTimes(1);
+      expect(observer.next).toBeCalledTimes(1);
+      expect(observer.next).toBeCalledWith({ data: 'Query one result' });
+      expect(observer.error).not.toBeCalled();
+      expect(observer.complete).toBeCalledTimes(1);
     });
 
     it('correctly executes the handler when the handler rejects', async () => {
       const handler = jest.fn().mockRejectedValue('Test error');
       mockLink.setRequestHandler(queryOne, handler);
+      const observer = createMockObserver();
+      
+      const observerable = mockLink.request(queryOneOperation);
 
-      const observer = mockLink.request(queryOneOperation);
-
-      const next = jest.fn();
-      const error = jest.fn();
-      const complete = jest.fn();
-
-      observer.subscribe(next, error, complete);
+      observerable.subscribe(observer);
 
       await new Promise(r => setTimeout(r, 0));
 
       expect(handler).toBeCalledTimes(1);
       expect(handler).toBeCalledWith({ a: 'one' });
 
-      expect(next).not.toBeCalled();
-      expect(error).toBeCalledTimes(1);
-      expect(error).toBeCalledWith('Test error');
-      expect(complete).not.toBeCalled();
+      expect(observer.next).not.toBeCalled();
+      expect(observer.error).toBeCalledTimes(1);
+      expect(observer.error).toBeCalledWith('Test error');
+      expect(observer.complete).not.toBeCalled();
     });
 
-    it('throws when the handler returns undefined', async () => {
-      const handler = jest.fn();
+    it('returns an error when the handler returns undefined', async () => {
+      const handler = jest.fn().mockReturnValue(undefined);
       mockLink.setRequestHandler(queryOne, handler);
+      const observer = createMockObserver();
 
-      expect(() => mockLink.request(queryOneOperation))
-        .toThrow("Request handler must return a promise. Received 'undefined'.");
+      const observable = mockLink.request(queryOneOperation);
+
+      observable.subscribe(observer);
+
+      await new Promise(r => setTimeout(r, 0));
+
+      expect(observer.next).not.toBeCalled();
+      expect(observer.error).toBeCalledTimes(1);
+      expect(observer.error).toBeCalledWith(new Error("Request handler must return a promise. Received 'undefined'."));
+      expect(observer.complete).not.toBeCalled();
     });
 
-    it('throws when the handler throws', async () => {
+    it('returns an error when the handler throws', async () => {
       const handler = jest.fn(() => { throw new Error('Error in handler') });
       mockLink.setRequestHandler(queryOne, handler);
+      const observer = createMockObserver();
 
-      expect(() => mockLink.request(queryOneOperation))
-        .toThrow("Unexpected error whilst calling request handler: Error in handler");
-    });
+      const observable = mockLink.request(queryOneOperation);
 
-    describe('when query contains @client directives', () => {
-      it('correctly executes the handler when query is entirely client side', async () => {
-        const clientSideQuery = gql`query One {one @client}`;
+      observable.subscribe(observer);
 
-        const handler = jest.fn().mockResolvedValue({ data: 'Query result' });
-        mockLink.setRequestHandler(clientSideQuery, handler);
+      await new Promise(r => setTimeout(r, 0));
 
-        const queryOperation = { query: clientSideQuery, variables: { a: 'one'} } as Partial<Operation> as Operation;
-
-        const observer = mockLink.request(queryOperation);
-
-        const next = jest.fn();
-        const error = jest.fn();
-        const complete = jest.fn();
-
-        observer.subscribe(next, error, complete);
-
-        await new Promise(r => setTimeout(r, 0));
-
-        expect(handler).toBeCalledTimes(1);
-        expect(handler).toBeCalledWith({ a: 'one' });
-
-        expect(next).toBeCalledTimes(1);
-        expect(next).toBeCalledWith({ data: 'Query result' });
-        expect(error).not.toBeCalled();
-        expect(complete).toBeCalledTimes(1);
-      });
-
-      it('correctly executes the handler when query is mixed and there are no client resolvers', async () => {
-        const mixedQuery = gql`query Two {a @client b}`;
-
-        const handler = jest.fn().mockResolvedValue({ data: 'Query result' });
-        mockLink.setRequestHandler(mixedQuery, handler);
-
-        // When there are no client resolvers, client directives get passed down to the link
-        const queryOperation = { query: mixedQuery, variables: { a: 'one'} } as Partial<Operation> as Operation;
-
-        const observer = mockLink.request(queryOperation);
-
-        const next = jest.fn();
-        const error = jest.fn();
-        const complete = jest.fn();
-
-        observer.subscribe(next, error, complete);
-
-        await new Promise(r => setTimeout(r, 0));
-
-        expect(handler).toBeCalledTimes(1);
-        expect(handler).toBeCalledWith({ a: 'one' });
-
-        expect(next).toBeCalledTimes(1);
-        expect(next).toBeCalledWith({ data: 'Query result' });
-        expect(error).not.toBeCalled();
-        expect(complete).toBeCalledTimes(1);
-      });
-
-      it('correctly executes the handler when query is mixed and there are client resolvers', async () => {
-        const mixedQuery = gql`query Two {a @client b}`;
-        const queryWithoutClientDirectives = gql`query Two {b}`;
-
-        const handler = jest.fn().mockResolvedValue({ data: 'Query result' });
-        mockLink.setRequestHandler(mixedQuery, handler);
-
-        // When there are client resolvers, client directives are removed before being passed down to the link
-        const queryOperation = { query: queryWithoutClientDirectives, variables: { a: 'one'} } as Partial<Operation> as Operation;
-
-        const observer = mockLink.request(queryOperation);
-
-        const next = jest.fn();
-        const error = jest.fn();
-        const complete = jest.fn();
-
-        observer.subscribe(next, error, complete);
-
-        await new Promise(r => setTimeout(r, 0));
-
-        expect(handler).toBeCalledTimes(1);
-        expect(handler).toBeCalledWith({ a: 'one' });
-
-        expect(next).toBeCalledTimes(1);
-        expect(next).toBeCalledWith({ data: 'Query result' });
-        expect(error).not.toBeCalled();
-        expect(complete).toBeCalledTimes(1);
-      });
+      expect(observer.next).not.toBeCalled();
+      expect(observer.error).toBeCalledTimes(1);
+      expect(observer.error).toBeCalledWith(new Error('Unexpected error whilst calling request handler: Error in handler'));
+      expect(observer.complete).not.toBeCalled();
     });
   });
 });

--- a/src/mockLink.ts
+++ b/src/mockLink.ts
@@ -1,5 +1,5 @@
-import { ApolloLink, DocumentNode, Observable, Operation, FetchResult } from 'apollo-link';
-import { hasDirectives, removeClientSetsFromDocument } from 'apollo-utilities';
+import { ApolloLink, DocumentNode, Observable, Operation, FetchResult } from '@apollo/client/core';
+import { hasDirectives, removeClientSetsFromDocument } from '@apollo/client/utilities';
 import { print } from 'graphql/language/printer';
 import { RequestHandler, RequestHandlerResponse } from './mockClient';
 


### PR DESCRIPTION
Updated `apollo-client` and related packages to the new `@apollo/client`

Fixes #11 

Fairly straight forward update process. Only breaking behaviour in `mock-apollo-client` is the fact that `@client` directives are no longer passed down to the link - they are always removed beforehand. Previously, in v2, `@client` directives would be passed to the link when there were no client resolvers registered. Special handling previously existed to handle both of these cases, which is no longer required. This means that 'client only' query handlers can no longer be supported.