### PR TITLE
Add subscription mock (0.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ export const GET_DOG_QUERY = gql`
 export const Dog = ({ name }) => (
   <Query query={GET_DOG_QUERY} variables={{ name }}>
     {({ loading, error, data }) => {
-      if (loading) return 'Loading...';
-      if (error) return 'Error!';
+      if (loading) return <p>Loading...</p>;
+      if (error) return <p>Error!</p>;
 
       return (
         <p>
@@ -184,8 +184,8 @@ export const SUBSCRIBE_DOG_DOCUMENT = gql`
 export const DogSubscription = ({ name }) => (
   <Subscription subscription={SUBSCRIBE_DOG_DOCUMENT} variables={{ name }}>
     {({ loading, error, data }) => {
-      if (loading) return 'Loading...';
-      if (error) return 'Error!';
+      if (loading) return <p>Loading...</p>;
+      if (error) return <p>Error!</p>;
 
       return (
         <p>

--- a/README.md
+++ b/README.md
@@ -160,6 +160,115 @@ mockApolloClient.setRequestHandler(
 
 Mutations can be tested the same way that queries are, by using `setRequestHandler` and specifying a request handler for the mutation query.
 
+### Subscriptions
+
+Subscriptions can be tested, but require a different setup as they receive a stream of data.
+Consider the file below, which contains a single subscription and a component which is responsible for rendering the updated data:
+```tsx
+// dogSubscription.tsx
+
+import * as React from 'react';
+import gql from 'graphql-tag';
+import { Subscription } from 'react-apollo';
+
+export const SUBSCRIBE_DOG_DOCUMENT = gql`
+  subscription subscribeDog($name: String) {
+    dog(name: $name) {
+      id
+      name
+      numberOfBarks
+    }
+  }
+`;
+
+export const DogSubscription = ({ name }) => (
+  <Subscription subscription={SUBSCRIBE_DOG_DOCUMENT} variables={{ name }}>
+    {({ loading, error, data }) => {
+      if (loading) return 'Loading...';
+      if (error) return 'Error!';
+
+      return (
+        <p>
+          {data.dog.name} has barked {data.dog.numberOfBarks} time(s)
+        </p>
+      );
+    }}
+  </Subscription>
+);
+```
+
+To unit test this component using `mock-apollo-client`, the test file could look like the following:
+
+```tsx
+// dogSubscription.test.tsx
+
+import { mount, ReactWrapper } from 'enzyme';
+import * as React from 'react';
+import { ApolloProvider } from 'react-apollo';
+import { createMockClient, createMockSubscription, IMockSubscription } from 'mock-apollo-client';
+
+import { SUBSCRIBE_DOG_DOCUMENT, DogSubscription } from './dogSubscription';
+
+let wrapper: ReactWrapper;
+let mockSubscription: IMockSubscription;
+
+beforeEach(() => {
+  const mockClient = createMockClient();
+  mockSubscription = createMockSubscription();
+
+  mockClient.setRequestHandler(
+    SUBSCRIBE_DOG_DOCUMENT,
+    () => mockSubscription);
+
+  wrapper = mount(
+    <ApolloProvider client={mockClient}>
+      <DogSubscription name="Rufus" />
+    </ApolloProvider>
+  );
+});
+
+it('renders the dog details', () => {
+  mockSubscription.next({ data: { dog: { id: 1, name: 'Rufus', numberOfBarks: 0 } } });
+  wrapper.update();
+
+  expect(wrapper.text()).toContain('Rufus has barked 0 time(s)');
+
+  mockSubscription.next({ data: { dog: { id: 1, name: 'Rufus', numberOfBarks: 1 } } });
+  wrapper.update();
+
+  expect(wrapper.text()).toContain('Rufus has barked 1 time(s)');
+});
+```
+
+The subscription can be closed by calling `.complete` if necessary for the test.
+
+#### Errors
+
+You can also test error states by calling `.error` on the `mockSubscription` and passing errors as described in [Error States](#error-states):
+```typescript
+mockSubscription.error(new Error('GraphQL Network Error'))
+```
+
+#### Multiple subscriptions
+
+A mock subscription will only be associated with a single invocation of a query. If a component is subscribing to the same query multiple times, then a separate mock subscription should be used for each one.
+
+```typescript
+const subscriptions: IMockSubscription[] = [];
+
+mockClient.setRequestHandler(
+  SUBSCRIBE_DOG_DOCUMENT,
+  () => {
+    const subscription = createMockSubscription();
+    subscriptions.push(subscription);
+    return subscription;
+  });
+
+...
+
+subscriptions.forEach((s) => s.next({ data: { dog: { id: 1, name: 'Rufus', numberOfBarks: 1 } } }));
+```
+
 ### Specifying Apollo client options
 
 The `createMockClient` method can be provided with the same constructor arguments that `ApolloClient` accepts which are used when instantiating the mock Apollo client.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './mockClient';
+export { createMockSubscription, IMockSubscription } from './mockSubscription';

--- a/src/mockClient.integration.test.ts
+++ b/src/mockClient.integration.test.ts
@@ -1,11 +1,12 @@
 import { InMemoryCache } from 'apollo-cache-inmemory';
-import { ApolloQueryResult } from 'apollo-client';
+import { ApolloQueryResult, ApolloError } from 'apollo-client';
 import gql from 'graphql-tag';
 
 // Currently do not test against all valid peer dependency versions of apollo
 // Would be nice to have, but can't find an elegant way of doing it.
 
 import { createMockClient, MockApolloClient } from './mockClient';
+import { createMockSubscription, IMockSubscription } from './mockSubscription';
 
 describe('MockClient integration tests', () => {
   let mockClient: MockApolloClient;
@@ -58,16 +59,10 @@ describe('MockClient integration tests', () => {
     });
 
     describe('Given request handler is not defined', () => {
-      let promise: Promise<ApolloQueryResult<any>>;
-
-      beforeEach(() => {
-        promise = mockClient.query({ query: queryTwo });
-      });
-
-      it('returns a promise which rejects due to handler not being defined', async () => {
-        expect(promise).toBeInstanceOf(Promise);
-
-        await expect(promise).rejects.toThrowError('Request handler not defined for query');
+      it('throws when executing the query', async () => {
+        await expect(mockClient.query({ query: queryTwo }))
+          .rejects
+          .toThrowError('Request handler not defined for query');
       });
     });
   });
@@ -392,6 +387,147 @@ describe('MockClient integration tests', () => {
 
         expect(console.warn).not.toBeCalled();
         expect(console.error).not.toBeCalled();
+      });
+    });
+  });
+
+  describe('Subscriptions', () => {
+    const queryOne = gql`query One {one}`;
+    const queryTwo = gql`query Two {two}`;
+
+    let mockSubscription: IMockSubscription<{ one: string }>;
+    let requestHandler: jest.Mock;
+
+    beforeEach(() => {
+      mockClient = createMockClient();
+
+      mockSubscription = createMockSubscription();
+
+      requestHandler = jest.fn().mockReturnValue(mockSubscription);
+
+      mockClient.setRequestHandler(queryOne, requestHandler);
+    });
+
+    describe('Given request handler is defined', () => {
+      let onNext: jest.Mock;
+      let onError: jest.Mock;
+      let onComplete: jest.Mock;
+
+      let clearMocks: () => void;
+
+      beforeEach(() => {
+        onNext = jest.fn();
+        onError = jest.fn();
+        onComplete = jest.fn();
+
+        clearMocks = () => {
+          onNext.mockClear();
+          onError.mockClear();
+          onComplete.mockClear();
+        };
+
+        const observable = mockClient.subscribe({ query: queryOne, variables: { a: 1 } });
+
+        observable.subscribe(
+          onNext,
+          onError,
+          onComplete);
+      });
+
+      it('returns an observable which produces the correct values until a GraphQL error is returned', async () => {
+        expect(onNext).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+        expect(onComplete).not.toHaveBeenCalled();
+
+        clearMocks();
+
+        mockSubscription.next({ data: { one: 'A' } });
+
+        expect(onNext).toHaveBeenCalledTimes(1);
+        expect(onNext).toHaveBeenCalledWith({ data: { one: 'A' } });
+        expect(onError).not.toHaveBeenCalled();
+        expect(onComplete).not.toHaveBeenCalled();
+
+        clearMocks();
+
+        mockSubscription.next({ data: { one: 'B' } });
+
+        expect(onNext).toHaveBeenCalledTimes(1);
+        expect(onNext).toHaveBeenCalledWith({ data: { one: 'B' } });
+        expect(onError).not.toHaveBeenCalled();
+        expect(onComplete).not.toHaveBeenCalled();
+
+        clearMocks();
+
+        mockSubscription.next({ errors: [{ message: 'GraphQL Error' }] });
+
+        expect(onNext).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledWith(new ApolloError({ graphQLErrors: [{ message: 'GraphQL Error' } as any] }));
+        expect(onComplete).not.toHaveBeenCalled();
+      });
+
+      it('returns an observable which produces the correct values until a GraphQL network error is returned', async () => {
+        expect(onNext).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+        expect(onComplete).not.toHaveBeenCalled();
+
+        clearMocks();
+
+        mockSubscription.next({ data: { one: 'A' } });
+
+        expect(onNext).toHaveBeenCalledTimes(1);
+        expect(onNext).toHaveBeenCalledWith({ data: { one: 'A' } });
+        expect(onError).not.toHaveBeenCalled();
+        expect(onComplete).not.toHaveBeenCalled();
+
+        clearMocks();
+
+        mockSubscription.error(new Error('GraphQL Network Error'));
+
+        expect(onNext).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith(new Error('GraphQL Network Error'));
+        expect(onComplete).not.toHaveBeenCalled();
+
+        expect(console.warn).not.toHaveBeenCalled();
+      });
+
+      it('returns an observable which produces the correct values until the subscription is completed', async () => {
+        expect(onNext).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+        expect(onComplete).not.toHaveBeenCalled();
+
+        clearMocks();
+
+        mockSubscription.next({ data: { one: 'A' } });
+
+        expect(onNext).toHaveBeenCalledTimes(1);
+        expect(onNext).toHaveBeenCalledWith({ data: { one: 'A' } });
+        expect(onError).not.toHaveBeenCalled();
+        expect(onComplete).not.toHaveBeenCalled();
+
+        clearMocks();
+
+        mockSubscription.complete();
+
+        expect(onNext).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+        expect(onComplete).toHaveBeenCalledTimes(1);
+        expect(onComplete).toHaveBeenCalledWith();
+
+        expect(console.warn).not.toHaveBeenCalled();
+      });
+
+      it('throws when a handler is added for the same query', () => {
+        expect(() => mockClient.setRequestHandler(queryOne, jest.fn())).toThrowError('Request handler already defined ');
+      });
+    });
+
+    describe('Given request handler is not defined', () => {
+      it('throws when attempting to subscribe to query', () => {
+        expect(() => mockClient.subscribe({ query: queryTwo }))
+          .toThrowError('Request handler not defined for query');
       });
     });
   });

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -3,11 +3,17 @@ import { InMemoryCache as Cache, NormalizedCacheObject } from 'apollo-cache-inme
 import { DocumentNode } from 'apollo-link';
 import { removeClientSetsFromDocument } from 'apollo-utilities';
 import { MockLink } from './mockLink';
+import { IMockSubscription } from './mockSubscription';
 
 export type RequestHandler<TData = any, TVariables = any> =
-  (variables: TVariables) => Promise<RequestHandlerResponse<TData>>;
+  (variables: TVariables) =>
+  | Promise<RequestHandlerResponse<TData>>
+  | IMockSubscription<TData>;
 
-export type RequestHandlerResponse<T> = { data: T, errors?: any[] };
+export type RequestHandlerResponse<T> =
+  | { data: T }
+  | { errors: any[] };
+
 
 export type MockApolloClient = ApolloClient<NormalizedCacheObject> &
   { setRequestHandler: (query: DocumentNode, handler: RequestHandler) => void };

--- a/src/mockSubscription.test.ts
+++ b/src/mockSubscription.test.ts
@@ -1,0 +1,107 @@
+import { FetchResult } from 'apollo-link';
+import { MockSubscription } from './mockSubscription';
+
+class MockObserver implements ZenObservable.SubscriptionObserver<FetchResult> {
+  closed: boolean;
+  next: (value: FetchResult) => void;
+  error: (errorValue: any) => void;
+  complete: () => void;
+
+  constructor() {
+    this.closed = false;
+    this.next = jest.fn();
+    this.error = jest.fn(() => {
+      this.closed = true;
+    });
+    this.complete = jest.fn(() => {
+      this.closed = true;
+    });
+  }
+}
+
+describe('class MockLink', () => {
+  let mockSubscription: MockSubscription;
+  let mockObserver: MockObserver;
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockReset();
+
+    mockSubscription = new MockSubscription();
+    mockObserver = new MockObserver();
+  });
+
+  describe('method subscribe', () => {
+    it('warns if overriding observer', () => {
+      mockSubscription.subscribe(mockObserver);
+      mockSubscription.subscribe(mockObserver);
+      expect(console.warn).toBeCalled();
+    });
+
+    it('does not warn if logging is disabled', () => {
+      mockSubscription = new MockSubscription({ disableLogging: true });
+      mockSubscription.subscribe(mockObserver);
+      mockSubscription.subscribe(mockObserver);
+      expect(console.warn).not.toBeCalled();
+    });
+  });
+
+  describe('method next', () => {
+    it('warns if the observer is not set', () => {
+      mockSubscription.next({ data: {} });
+      expect(console.warn).toBeCalled();
+    });
+
+    it('warns if the observer is closed', () => {
+      mockSubscription.subscribe(mockObserver);
+      mockObserver.closed = true;
+      mockSubscription.next({ data: {} });
+      expect(console.warn).toBeCalled();
+    });
+
+    it('does not warn if logging is disabled', () => {
+      mockSubscription = new MockSubscription({ disableLogging: true });
+      mockSubscription.next({ data: {} });
+      expect(console.warn).not.toBeCalled();
+    });
+  });
+
+  describe('method error', () => {
+    it('warns if the observer is not set', () => {
+      mockSubscription.error(new Error());
+      expect(console.warn).toBeCalled();
+    });
+
+    it('warns if the observer is closed', () => {
+      mockSubscription.subscribe(mockObserver);
+      mockObserver.closed = true;
+      mockSubscription.error(new Error());
+      expect(console.warn).toBeCalled();
+    });
+
+    it('does not warn if logging is disabled', () => {
+      mockSubscription = new MockSubscription({ disableLogging: true });
+      mockSubscription.error(new Error());
+      expect(console.warn).not.toBeCalled();
+    });
+  });
+
+  describe('method complete', () => {
+    it('warns if the observer is not set', () => {
+      mockSubscription.complete();
+      expect(console.warn).toBeCalled();
+    });
+
+    it('warns if the observer is closed', () => {
+      mockSubscription.subscribe(mockObserver);
+      mockObserver.closed = true;
+      mockSubscription.complete();
+      expect(console.warn).toBeCalled();
+    });
+
+    it('does not warn if logging is disabled', () => {
+      mockSubscription = new MockSubscription({ disableLogging: true });
+      mockSubscription.complete();
+      expect(console.warn).not.toBeCalled();
+    });
+  });
+});

--- a/src/mockSubscription.ts
+++ b/src/mockSubscription.ts
@@ -1,0 +1,70 @@
+import type { FetchResult } from 'apollo-link';
+import type { RequestHandlerResponse } from './mockClient';
+
+export interface IMockSubscription<TData = any> {
+  readonly closed: boolean;
+  next: (value: RequestHandlerResponse<TData>) => void;
+  error: (errorValue: any) => void;
+  complete: () => void;
+}
+
+export type MockSubscriptionOptions = {
+  disableLogging?: boolean
+}
+
+export class MockSubscription<TData = any> implements IMockSubscription<TData> {
+  private observer?: ZenObservable.SubscriptionObserver<FetchResult>;
+  private loggingDisabled: boolean;
+
+  constructor(options?: MockSubscriptionOptions) {
+    this.loggingDisabled = options?.disableLogging ?? false;
+  }
+
+  subscribe(observer: ZenObservable.SubscriptionObserver<FetchResult>) {
+    if (this.observer && !this.loggingDisabled) {
+      console.warn(
+        'Warning: mock-apollo-client - Mock subscription was already being used for a previous query. ' +
+        'Subsequent calls to next/error/complete will only affect subscriptions to the new query.'
+      );
+    }
+    this.observer = observer;
+  }
+
+  get closed() {
+    return this.observer?.closed ?? true;
+  }
+
+  next(value: RequestHandlerResponse<TData>) {
+    this.verifyState();
+    this.observer?.next(value);
+  }
+
+  error(errorValue: any) {
+    this.verifyState();
+    this.observer?.error(errorValue);
+  }
+
+  complete() {
+    this.verifyState();
+    this.observer?.complete();
+  }
+
+  private verifyState() {
+    if (this.loggingDisabled) {
+      return;
+    }
+
+    if (!this.observer) {
+      console.warn(
+        'Warning: mock-apollo-client - Mock subscription has no observer, this will have no effect'
+      );
+    } else if (this.closed) {
+      console.warn(
+        'Warning: mock-apollo-client - Mock subscription is closed, this will have no effect'
+      );
+    }
+  }
+}
+
+export const createMockSubscription = <TData = any>(options?: MockSubscriptionOptions) =>
+  new MockSubscription<TData>(options) as IMockSubscription<TData>;


### PR DESCRIPTION
Implements subscriptions for 0.x (Apollo 2), which is taken from the 1.x (Apollo 3) implementation in #26 

Addresses #28 