### PR TITLE
Configure behaviour for missing request handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
+.idea
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -276,6 +276,21 @@ const cache = new InMemoryCache({
 const mockClient = createMockClient({ cache });
 ```
 
+Additionally, you can specify a `missingHandlerPolicy` to define the behavior of the mock client when a request handler for a particular operation is not found.
+
+The `missingHandlerPolicy` accepts one of three string values:
+- `'throw-error'`: The client throws an error when it encounters a missing handler.
+- `'warn-and-return-error'`: The client logs a warning message in the console and returns an error.
+- `'return-error'`: The client returns an error without any warning message.
+
+Here's an example of how you can set the `missingHandlerPolicy`:
+
+```typescript
+const mockClient = createMockClient({ missingHandlerPolicy: 'warn-and-return-error' });
+```
+
+In this example, if a request handler for a given operation is not found, the client will log a warning message to the console and then return an error.
+
 Note: it is not possible to specify the `link` to use as this is how `mock-apollo-client` injects its behaviour.
 
 ### Fragments

--- a/src/mockClient.integration.test.ts
+++ b/src/mockClient.integration.test.ts
@@ -5,7 +5,6 @@ import { ApolloQueryResult, gql, InMemoryCache } from '@apollo/client/core';
 
 import { createMockClient, MockApolloClient } from './mockClient';
 import { createMockSubscription, IMockSubscription } from './mockSubscription';
-import { print } from "graphql";
 
 describe('MockClient integration tests', () => {
   let mockClient: MockApolloClient;
@@ -56,10 +55,9 @@ describe('MockClient integration tests', () => {
     });
 
     describe('Given request handler is not defined', () => {
-      it('returns a promise which rejects due to handler not being defined', async () => {
-        let promise =  mockClient.query({ query: queryTwo });
-
-        await expect(promise).rejects.toThrowError('Request handler not defined for query');
+      it('throws when executing the query', () => {
+        expect(() => mockClient.query({ query: queryTwo }))
+          .toThrowError('Request handler not defined for query');
       });
     });
   });
@@ -543,27 +541,9 @@ describe('MockClient integration tests', () => {
     });
 
     describe('Given request handler is not defined', () => {
-      it('returns an observable which returns error if handler not defined for query', async () => {
-        let onNext = jest.fn();
-        let onError = jest.fn();
-        let onComplete = jest.fn();
-
-        const observable = mockClient.subscribe({ query: queryTwo });
-
-        observable.subscribe(
-            onNext,
-            onError,
-            onComplete
-        );
-
-        await new Promise(r => setTimeout(r, 0));
-
-        mockSubscription.next({ data: { one: 'A' } });
-
-        expect(onNext).not.toHaveBeenCalled();
-        expect(onError).toHaveBeenCalledWith(new Error(`Request handler not defined for query: ${print(queryTwo)}`));
-        expect(onError).toHaveBeenCalledTimes(1);
-        expect(onComplete).not.toHaveBeenCalled();
+      it('throws when attempting to subscribe to query', () => {
+        expect(() => mockClient.subscribe({ query: queryTwo }))
+          .toThrowError('Request handler not defined for query');
       });
     });
   });

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -1,6 +1,6 @@
 import { ApolloClientOptions, ApolloClient, DocumentNode } from '@apollo/client/core';
 import { InMemoryCache as Cache, NormalizedCacheObject } from '@apollo/client/cache';
-import { MockLink } from './mockLink';
+import { MissingHandlerPolicy, MockLink } from './mockLink';
 import { IMockSubscription } from './mockSubscription';
 
 export type RequestHandler<TData = any, TVariables = any> =
@@ -15,7 +15,11 @@ export type RequestHandlerResponse<T> =
 export type MockApolloClient = ApolloClient<NormalizedCacheObject> &
   { setRequestHandler: (query: DocumentNode, handler: RequestHandler) => void };
 
-export type MockApolloClientOptions = Partial<Omit<ApolloClientOptions<NormalizedCacheObject>, 'link'>> | undefined;
+interface CustomOptions {
+  missingHandlerPolicy?: MissingHandlerPolicy;
+}
+
+export type MockApolloClientOptions = Partial<Omit<ApolloClientOptions<NormalizedCacheObject>, 'link'>> & CustomOptions | undefined;
 
 export const createMockClient = (options?: MockApolloClientOptions): MockApolloClient => {
   if ((options as any)?.link) {

--- a/src/mockLink.test.ts
+++ b/src/mockLink.test.ts
@@ -89,9 +89,18 @@ describe('class MockLink', () => {
       complete: jest.fn(),
     });
 
-    it('throws when a handler is not defined for the query', () => {
-      expect(() => mockLink.request(queryOneOperation))
-        .toThrowError(`Request handler not defined for query: ${print(queryOne)}`)
+    it('returns an error when a handler is not defined for the query', async () => {
+      const observable = mockLink.request(queryOneOperation);
+      const observer = createMockObserver();
+
+      observable.subscribe(observer);
+
+      await new Promise(r => setTimeout(r, 0));
+
+      expect(observer.next).not.toBeCalled();
+      expect(observer.error).toBeCalledTimes(1);
+      expect(observer.error).toBeCalledWith(new Error(`Request handler not defined for query: ${print(queryOne)}`));
+      expect(observer.complete).not.toBeCalled();
     });
 
     it('correctly executes the handler when the handler is defined as a promise and it and successfully resolves', async () => {

--- a/src/mockLink.test.ts
+++ b/src/mockLink.test.ts
@@ -263,7 +263,7 @@ describe('class MockLink', () => {
       expect(console.warn).toBeCalledWith(`Request handler not defined for query: ${print(queryOne)}`);
     });
 
-    it('when "ignore" returns an error when a handler is not defined for the query', async () => {
+    it('when "return-error" returns an error when a handler is not defined for the query', async () => {
       mockLink = new MockLink({missingHandlerPolicy: 'return-error'})
 
       const observable = mockLink.request(queryOneOperation);

--- a/src/mockLink.test.ts
+++ b/src/mockLink.test.ts
@@ -10,6 +10,14 @@ describe('class MockLink', () => {
   const queryOne = gql`query One {one}`;
   const queryTwo = gql`query Two {two}`;
 
+  const queryOneOperation = { query: queryOne, variables: { a: 'one' } } as Partial<Operation> as Operation;
+
+  const createMockObserver = (): jest.Mocked<Observer<any>> => ({
+    next: jest.fn(),
+    error: jest.fn(),
+    complete: jest.fn(),
+  });
+
   beforeEach(() => {
     jest.spyOn(console, 'warn')
       .mockReset();
@@ -81,28 +89,6 @@ describe('class MockLink', () => {
   });
 
   describe('method request', () => {
-    const queryOneOperation = { query: queryOne, variables: { a: 'one' } } as Partial<Operation> as Operation;
-
-    const createMockObserver = (): jest.Mocked<Observer<any>> => ({
-      next: jest.fn(),
-      error: jest.fn(),
-      complete: jest.fn(),
-    });
-
-    it('returns an error when a handler is not defined for the query', async () => {
-      const observable = mockLink.request(queryOneOperation);
-      const observer = createMockObserver();
-
-      observable.subscribe(observer);
-
-      await new Promise(r => setTimeout(r, 0));
-
-      expect(observer.next).not.toBeCalled();
-      expect(observer.error).toBeCalledTimes(1);
-      expect(observer.error).toBeCalledWith(new Error(`Request handler not defined for query: ${print(queryOne)}`));
-      expect(observer.complete).not.toBeCalled();
-    });
-
     it('correctly executes the handler when the handler is defined as a promise and it and successfully resolves', async () => {
       const handler = jest.fn().mockResolvedValue({ data: 'Query one result' });
       mockLink.setRequestHandler(queryOne, handler);
@@ -251,4 +237,46 @@ describe('class MockLink', () => {
       expect(observer.complete).toBeCalledTimes(1);
     });
   });
+
+  describe('constructor option "missingHandlerPolicy"', () => {
+    it('when "throw-error" throws when a handler is not defined for the query', () => {
+      mockLink = new MockLink({missingHandlerPolicy: 'throw-error'})
+
+      expect(() => mockLink.request(queryOneOperation))
+        .toThrowError(`Request handler not defined for query: ${print(queryOne)}`)
+    });
+
+    it('when "warn-and-return-error" logs a warning when a handler is not defined for the query', async () => {
+      mockLink = new MockLink({missingHandlerPolicy: 'warn-and-return-error'})
+
+      const observable = mockLink.request(queryOneOperation);
+      const observer = createMockObserver();
+
+      observable.subscribe(observer);
+
+      await new Promise(r => setTimeout(r, 0));
+
+      expect(observer.next).not.toBeCalled();
+      expect(observer.error).toBeCalled();
+      expect(observer.complete).not.toBeCalled();
+      expect(console.warn).toBeCalledTimes(1);
+      expect(console.warn).toBeCalledWith(`Request handler not defined for query: ${print(queryOne)}`);
+    });
+
+    it('when "ignore" returns an error when a handler is not defined for the query', async () => {
+      mockLink = new MockLink({missingHandlerPolicy: 'return-error'})
+
+      const observable = mockLink.request(queryOneOperation);
+      const observer = createMockObserver();
+
+      observable.subscribe(observer);
+
+      await new Promise(r => setTimeout(r, 0));
+
+      expect(observer.next).not.toBeCalled();
+      expect(observer.error).toBeCalledTimes(1);
+      expect(observer.error).toBeCalledWith(new Error(`Request handler not defined for query: ${print(queryOne)}`));
+      expect(observer.complete).not.toBeCalled();
+    });
+  })
 });

--- a/src/mockLink.ts
+++ b/src/mockLink.ts
@@ -25,15 +25,15 @@ export class MockLink extends ApolloLink {
   }
 
   request = (operation: Operation) => {
-    const key = requestToKey(operation.query);
-
-    const handler = this.requestHandlers[key];
-
-    if (!handler) {
-      throw new Error(`Request handler not defined for query: ${print(operation.query)}`);
-    }
-
     return new Observable<FetchResult>(observer => {
+      const key = requestToKey(operation.query);
+
+      const handler = this.requestHandlers[key];
+
+      if (!handler) {
+        throw new Error(`Request handler not defined for query: ${print(operation.query)}`);
+      }
+
       let result:
         | Promise<RequestHandlerResponse<any>>
         | IMockSubscription<any>


### PR DESCRIPTION
### Motivation
The current implementation of a library throws an error if at least one executed query wasn't mocked.

For example, when using Apollo together with React you could have a `<Component1 />` that is using `queryOne`, and `<Component2 />` which is a deep child of a `<Component1 />` and is using `queryTwo`. I'm writing a unit test for `<Component1 />` and mocking a response for a `queryOne`. However, my test will fail because I haven't provided a mock for a queryTwo with smth like `Error: Request handler not defined for query: query queryTwo`. I've attached a sandbox with a reproduction of this issue.
It's very inconvenient to provide mocks for all requests because the rendered tree could be huge, so you should know the implementation of your children to do it, and should frequently update in case of changes.

Additional motivation for this change:
1.  Align with apollo-client/testing MockedProvider -> MockLink implementation [where an error is thrown inside of the returned observable.](https://github.com/apollographql/apollo-client/blob/main/src/testing/core/mocking/mockLink.ts#L174)
2. This change returns behaviour regarding throwing an error to how it was before the 1.1.0 version. In 1.1.0 you introduced subscription [but also changed how errors are thrown.](https://github.com/Mike-Gibson/mock-apollo-client/pull/26#discussion_r1473123973)

### Description of change
Throw an error inside of the observable that is returned from the request method instead of throwing it directly in the function body.

### How to reproduce
[Sandbox where you can reproduce the issue](https://codesandbox.io/p/devbox/mock-apollo-issue-zw46l3?file=%2Fsrc%2FParentComponent.spec.tsx%3A11%2C3). Login, fork and run `npm run test` in the sandbox terminal. You can uncomment mock for a second query or downgrade to mock-apollo-client@1.0.0 to fix the issue in a sandbox