### PR TITLE
fix: missingHandlerPolicy not passed to a MockLink when creating a client

### DIFF
--- a/src/mockClient.integration.test.ts
+++ b/src/mockClient.integration.test.ts
@@ -1,4 +1,5 @@
 import { ApolloQueryResult, gql, InMemoryCache } from '@apollo/client/core';
+import { print } from 'graphql';
 
 // Currently do not test against all valid peer dependency versions of apollo
 // Would be nice to have, but can't find an elegant way of doing it.
@@ -58,6 +59,18 @@ describe('MockClient integration tests', () => {
       it('throws when executing the query', () => {
         expect(() => mockClient.query({ query: queryTwo }))
           .toThrowError('Request handler not defined for query');
+      });
+
+      it('returns a promise which rejects and but warns in console when a handler not being defined and missingHandlerPolicy is "warn-and-return-error"', async () => {
+        mockClient = createMockClient({
+          missingHandlerPolicy: 'warn-and-return-error',
+        });
+
+        let promise =  mockClient.query({ query: queryTwo });
+
+        await expect(promise).rejects.toThrowError('Request handler not defined for query');
+        expect(console.warn).toBeCalledTimes(1);
+        expect(console.warn).toBeCalledWith(`Request handler not defined for query: ${print(queryTwo)}`);
       });
     });
   });

--- a/src/mockClient.ts
+++ b/src/mockClient.ts
@@ -19,20 +19,21 @@ interface CustomOptions {
   missingHandlerPolicy?: MissingHandlerPolicy;
 }
 
-export type MockApolloClientOptions = Partial<Omit<ApolloClientOptions<NormalizedCacheObject>, 'link'>> & CustomOptions | undefined;
+export type MockApolloClientOptions = (Partial<Omit<ApolloClientOptions<NormalizedCacheObject>, 'link'>> & CustomOptions) | undefined;
 
-export const createMockClient = (options?: MockApolloClientOptions): MockApolloClient => {
+export const createMockClient = (options: MockApolloClientOptions = {}): MockApolloClient => {
   if ((options as any)?.link) {
     throw new Error('Providing link to use is not supported.');
   }
+  const { missingHandlerPolicy, ...restOptions } = options;
 
-  const mockLink = new MockLink();
+  const mockLink = new MockLink({ missingHandlerPolicy });
 
   const client = new ApolloClient({
     cache: new Cache({
       addTypename: false,
     }),
-    ...options,
+    ...restOptions,
     link: mockLink
   });
 


### PR DESCRIPTION
I've added `missingHandlerPolicy` field for the MockLink and as an option for the `createMockClient` in [my previous PR](https://github.com/Mike-Gibson/mock-apollo-client/pull/55)
However, it wasn't passed from to a `MockLink` when it was initialized inside of the `createMockClient`.
I fixed it in this PR and added an integration test for it