### PR TITLE
Extend test suite to run against apollo up to 3.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
-        "@apollo/client": "^3.9.11",
+        "@apollo/client": "3.13",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.7",
         "graphql": "^15.8.0",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.9.11",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.9.11.tgz",
-      "integrity": "sha512-H7e9m7cRcFO93tokwzqrsbnfKorkpV24xU30hFH5u2g6B+c1DMo/ouyF/YrBPdrTzqxQCjTUmds/FLmJ7626GA==",
+      "version": "3.13.9",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.9.tgz",
+      "integrity": "sha512-RStSzQfL1XwL6/NWd7W8avhGQYTgPCtJ+qHkkTTSj9Upp3VVm6Oppv81YWdXG1FgEpDPW4hvCrTUELdcC4inCQ==",
       "dev": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -48,8 +48,7 @@
         "hoist-non-react-statics": "^3.3.2",
         "optimism": "^0.18.0",
         "prop-types": "^15.7.2",
-        "rehackt": "0.0.6",
-        "response-iterator": "^0.2.6",
+        "rehackt": "^0.1.0",
         "symbol-observable": "^4.0.0",
         "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
@@ -57,9 +56,9 @@
       },
       "peerDependencies": {
         "graphql": "^15.0.0 || ^16.0.0",
-        "graphql-ws": "^5.5.5",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "graphql-ws": "^5.5.5 || ^6.0.3",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
         "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
@@ -4022,9 +4021,9 @@
       "dev": true
     },
     "node_modules/rehackt": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.0.6.tgz",
-      "integrity": "sha512-l3WEzkt4ntlEc/IB3/mF6SRgNHA6zfQR7BlGOgBTOmx7IJJXojDASav+NsgXHFjHn+6RmwqsGPFgZpabWpeOdw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
       "dev": true,
       "peerDependencies": {
         "@types/react": "*",
@@ -4093,15 +4092,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/response-iterator": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
-      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/semver": {
@@ -4705,9 +4695,9 @@
       }
     },
     "@apollo/client": {
-      "version": "3.9.11",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.9.11.tgz",
-      "integrity": "sha512-H7e9m7cRcFO93tokwzqrsbnfKorkpV24xU30hFH5u2g6B+c1DMo/ouyF/YrBPdrTzqxQCjTUmds/FLmJ7626GA==",
+      "version": "3.13.9",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.9.tgz",
+      "integrity": "sha512-RStSzQfL1XwL6/NWd7W8avhGQYTgPCtJ+qHkkTTSj9Upp3VVm6Oppv81YWdXG1FgEpDPW4hvCrTUELdcC4inCQ==",
       "dev": true,
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -4718,8 +4708,7 @@
         "hoist-non-react-statics": "^3.3.2",
         "optimism": "^0.18.0",
         "prop-types": "^15.7.2",
-        "rehackt": "0.0.6",
-        "response-iterator": "^0.2.6",
+        "rehackt": "^0.1.0",
         "symbol-observable": "^4.0.0",
         "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
@@ -7769,9 +7758,9 @@
       "dev": true
     },
     "rehackt": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.0.6.tgz",
-      "integrity": "sha512-l3WEzkt4ntlEc/IB3/mF6SRgNHA6zfQR7BlGOgBTOmx7IJJXojDASav+NsgXHFjHn+6RmwqsGPFgZpabWpeOdw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
       "dev": true,
       "requires": {}
     },
@@ -7811,12 +7800,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
       "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
-      "dev": true
-    },
-    "response-iterator": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
-      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
       "dev": true
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/mike-gibson/mock-apollo-client#readme",
   "devDependencies": {
-    "@apollo/client": "^3.9.11",
+    "@apollo/client": "3.13",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.7",
     "graphql": "^15.8.0",

--- a/runTestSuite.sh
+++ b/runTestSuite.sh
@@ -15,6 +15,11 @@ apolloVersions=(
   "@apollo/client@3.7.17"
   "@apollo/client@3.8.10"
   "@apollo/client@3.9.11"
+  "@apollo/client@3.10.8"
+  "@apollo/client@3.11.10"
+  "@apollo/client@3.12.11"
+  "@apollo/client@3.12.11"
+  "@apollo/client@3.13.9"
 )
 exitStatus=0
 


### PR DESCRIPTION
Note: tried including Apollo 3.14.0, but new deprecations mean extra warnings are logged, and not sure how to tackle those, so not including that for now.